### PR TITLE
getallvms.py - add uuid to summary

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -47,6 +47,8 @@ def print_vm_info(virtual_machine, depth=1):
     print "Name       : ", summary.config.name
     print "Path       : ", summary.config.vmPathName
     print "Guest      : ", summary.config.guestFullName
+    print "Instance UUID : ", summary.config.instanceUuid
+    print "Bios UUID     : ", summary.config.uuid
     annotation = summary.config.annotation
     if annotation:
         print "Annotation : ", annotation


### PR DESCRIPTION
To help new developers bootstrap into other samples, this
sample should include a listing of UUID as well. Because you
can use searchIndex with instance or bios UUID (but you have
to tell searchIndex which type of UUID you're using).
