### PR TITLE
Added a sample to shut down a vm and destroy it

### DIFF
--- a/samples/destroy_vm.py
+++ b/samples/destroy_vm.py
@@ -1,0 +1,85 @@
+# Copyright 2015 Michael Rice <michael@michaelrice.org>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import print_function
+
+import atexit
+
+import requests
+from pyVim import connect
+
+from tools import cli
+from tools import tasks
+
+requests.packages.urllib3.disable_warnings()
+
+
+def setup_args():
+    """Adds additional ARGS to allow the vm name or uuid to
+    be set.
+    """
+    parser = cli.build_arg_parser()
+    # using j here because -u is used for user
+    parser.add_argument('-j', '--uuid',
+                        help='BIOS UUID of the VirtualMachine you want '
+                             'to reboot.')
+    parser.add_argument('-n', '--name',
+                        help='DNS Name of the VirtualMachine you want to '
+                             'reboot.')
+    parser.add_argument('-i', '--ip',
+                        help='IP Address of the VirtualMachine you want to '
+                             'reboot')
+
+    my_args = parser.parse_args()
+
+    return cli.prompt_for_password(my_args)
+
+
+ARGS = setup_args()
+SI = None
+try:
+    SI = connect.SmartConnect(host=ARGS.host,
+                              user=ARGS.user,
+                              pwd=ARGS.password,
+                              port=ARGS.port)
+    atexit.register(connect.Disconnect, SI)
+except IOError, ex:
+    pass
+
+if not SI:
+    raise SystemExit("Unable to connect to host with supplied info.")
+VM = None
+if ARGS.uuid:
+    VM = SI.content.searchIndex.FindByUuid(None, ARGS.uuid,
+                                           True,
+                                           False)
+elif ARGS.name:
+    VM = SI.content.searchIndex.FindByDnsName(None, ARGS.name,
+                                              True)
+elif ARGS.ip:
+    VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
+
+if VM is None:
+    raise SystemExit("Unable to locate VirtualMachine.")
+
+print("Found: {0}".format(VM.name))
+print("The current powerState is: {0}".format(VM.runtime.powerState))
+print("Attempting to power off {0}".format(VM.name))
+TASK = VM.PowerOffVM_Task()
+tasks.wait_for_tasks(SI, [TASK])
+print("{0}".format(TASK.info.state))
+print("Destroying VM from vSphere.")
+TASK = VM.Destroy_Task()
+tasks.wait_for_tasks(SI, [TASK])
+print("Done.")


### PR DESCRIPTION
This sample can use a name, IP, or BIOS UUID to locate
a VirtualMachine. Next it powers the VM off next it
does a destroy on the ManagedEntity to remove it from
inventory and delete its disk. This sample addresses
a request from StackOverflow:
http://stackoverflow.com/questions/27519058/is-there-a-way-to-delete-a-guest-vm-using-the-pyvmomi-api